### PR TITLE
go: strings: willi's algorithm for finding the string blob

### DIFF
--- a/floss/language/go/extract.py
+++ b/floss/language/go/extract.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2023 Mandiant, Inc. All Rights Reserved.
 
+from dataclasses import dataclass
+import pathlib
 import re
 import sys
 import struct
 import logging
 import argparse
-from typing import List, Iterable, Optional
+import collections
+from typing import List, Iterable, Optional, Tuple, TypeAlias, Dict
 from pathlib import Path
 from itertools import chain
 
@@ -40,6 +43,324 @@ def extract_stackstrings(extract_stackstring_pattern, section_data, min_length) 
     return stack_strings
 
 
+VA: TypeAlias = int
+
+
+def get_amd64_lea_xrefs(buf: bytes, base_addr: VA) -> Iterable[VA]:
+    rip_relative_insn_length = 7
+    rip_relative_insn_re = re.compile(b"""
+        (
+              \x48 \x8D \x05  # 48 8d 05 aa aa 00 00    lea    rax,[rip+0xaaaa] 
+            | \x48 \x8D \x0D  # 48 8d 0d aa aa 00 00    lea    rcx,[rip+0xaaaa]
+            | \x48 \x8D \x15  # 48 8d 15 aa aa 00 00    lea    rdx,[rip+0xaaaa]
+            | \x48 \x8D \x1D  # 48 8d 1d aa aa 00 00    lea    rbx,[rip+0xaaaa]
+            | \x48 \x8D \x2D  # 48 8d 2d aa aa 00 00    lea    rbp,[rip+0xaaaa]
+            | \x48 \x8D \x35  # 48 8d 35 aa aa 00 00    lea    rsi,[rip+0xaaaa]
+            | \x48 \x8D \x3D  # 48 8d 3d aa aa 00 00    lea    rdi,[rip+0xaaaa]
+            | \x4C \x8D \x05  # 4c 8d 05 aa aa 00 00    lea     r8,[rip+0xaaaa]
+            | \x4C \x8D \x0D  # 4c 8d 0d aa aa 00 00    lea     r9,[rip+0xaaaa] 
+            | \x4C \x8D \x15  # 4c 8d 15 aa aa 00 00    lea    r10,[rip+0xaaaa]
+            | \x4C \x8D \x1D  # 4c 8d 1d aa aa 00 00    lea    r11,[rip+0xaaaa]
+            | \x4C \x8D \x25  # 4c 8d 25 aa aa 00 00    lea    r12,[rip+0xaaaa]
+            | \x4C \x8D \x2D  # 4c 8d 2d aa aa 00 00    lea    r13,[rip+0xaaaa]
+            | \x4C \x8D \x35  # 4c 8d 35 aa aa 00 00    lea    r14,[rip+0xaaaa]
+            | \x4C \x8D \x3D  # 4c 8d 3d aa aa 00 00    lea    r15,[rip+0xaaaa]
+        )
+        (?P<offset>....)
+        """, re.DOTALL + re.VERBOSE
+    )
+
+    for match in rip_relative_insn_re.finditer(buf):
+        offset_bytes = match.group("offset")
+        offset = struct.unpack("<i", offset_bytes)[0]
+
+        yield base_addr + match.start() + offset + rip_relative_insn_length
+
+
+def get_i386_lea_xrefs(buf: bytes) -> Iterable[VA]:
+    absolute_insn_re = re.compile(b"""
+        (
+              \x8D \x05  # 8d 05 aa aa 00 00       lea    eax,ds:0xaaaa
+            | \x8D \x1D  # 8d 1d aa aa 00 00       lea    ebx,ds:0xaaaa
+            | \x8D \x0D  # 8d 0d aa aa 00 00       lea    ecx,ds:0xaaaa
+            | \x8D \x15  # 8d 15 aa aa 00 00       lea    edx,ds:0xaaaa
+            | \x8D \x35  # 8d 35 aa aa 00 00       lea    esi,ds:0xaaaa
+            | \x8D \x3D  # 8d 3d aa aa 00 00       lea    edi,ds:0xaaaa
+        )
+        (?P<address>....)
+        """, re.DOTALL + re.VERBOSE
+    )
+
+    for match in absolute_insn_re.finditer(buf):
+        address_bytes = match.group("address")
+        address = struct.unpack("<I", address_bytes)[0]
+
+        yield address
+
+
+def get_image_range(pe: pefile.PE) -> Tuple[VA, VA]:
+    """Return the range of the image in memory."""
+    image_base = pe.OPTIONAL_HEADER.ImageBase
+    image_size = pe.OPTIONAL_HEADER.SizeOfImage
+    return image_base, image_base + image_size
+
+
+def get_lea_xrefs(pe: pefile.PE) -> Iterable[VA]:
+    low, high = get_image_range(pe)
+
+    for section in pe.sections:
+        if not section.IMAGE_SCN_MEM_EXECUTE:
+            continue
+
+        code = section.get_data()
+
+        if pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_AMD64"]: 
+            xrefs = get_amd64_lea_xrefs(code, section.VirtualAddress + pe.OPTIONAL_HEADER.ImageBase)
+        elif pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_I386"]:
+            xrefs = get_i386_lea_xrefs(code)
+        else:
+            raise ValueError("unhandled architecture")
+
+        for xref in xrefs:
+            if low <= xref < high:
+                yield xref
+
+
+@dataclass
+class StructString:
+    address: VA
+    length: int
+
+
+def get_amd64_struct_string_candidates(buf: bytes) -> Iterable[StructString]:
+    for offset in range(0, len(buf) - 0x8, 0x8):
+        address, length = struct.unpack_from("<QQ", buf, offset)
+        yield StructString(address, length)
+
+
+def get_i386_struct_string_candidates(buf: bytes) -> Iterable[StructString]:
+    for offset in range(0, len(buf) - 0x4, 0x4):
+        address, length = struct.unpack_from("<II", buf, offset)
+        yield StructString(address, length)
+
+
+def get_struct_string_instances(pe: pefile.PE) -> Iterable[StructString]:
+    image_base = pe.OPTIONAL_HEADER.ImageBase
+    low, high = get_image_range(pe)
+
+    for section in pe.sections:
+        if section.IMAGE_SCN_MEM_EXECUTE:
+            continue
+
+        if not section.IMAGE_SCN_MEM_READ:
+            continue
+
+        data = section.get_data()
+
+        if pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_AMD64"]: 
+            candidates = get_amd64_struct_string_candidates(data)
+        elif pe.FILE_HEADER.Machine == pefile.MACHINE_TYPE["IMAGE_FILE_MACHINE_I386"]:
+            candidates = get_i386_struct_string_candidates(data)
+        else:
+            raise ValueError("unhandled architecture")
+
+        for candidate in candidates:
+            va = candidate.address
+            rva = va - image_base
+
+            if not (low <= va < high):
+                continue
+
+            target_section = pe.get_section_by_rva(rva)
+            if not target_section:
+                # string instance must be in a section
+                continue
+
+            if target_section.IMAGE_SCN_MEM_EXECUTE:
+                # string instances aren't found with the code
+                continue
+
+            if not target_section.IMAGE_SCN_MEM_READ:
+                # string instances must be readable, naturally
+                continue
+
+            try:
+                sbuf = pe.get_data(rva, candidate.length)
+            except pefile.PEFormatError:
+                # failed to read data at RVA
+                continue
+
+            if len(sbuf) != candidate.length:
+                # we must be able to read the entire string data
+                # or it is not a valid Go string
+                continue
+
+            try:
+                s = sbuf.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+
+            if not s:
+                continue
+
+            if s.encode("utf-8") != sbuf:
+                # re-encoding the string should produce the same bytes,
+                # otherwise, the string may not be the length intended.
+                continue
+
+            yield candidate
+
+
+def get_string_blob_range(pe: pefile.PE) -> Tuple[VA, VA]:
+    """
+    find the most common range of bytes between | 00 00 | pairs
+    that contains the data from a likely struct string.
+   
+    we don't expect UTF-8 data to ever contain | 00 00 |, so this
+    shouldn't be found in the string blob.
+
+    we assume that the range with the most pointers like this is
+    the string blob. this might not be the case if:
+      - there's more than one string blob
+      - there's lots of structures that look like struct String but aren't
+      - ???
+
+    these don't seem likely today, but possible.
+    """
+    image_base = pe.OPTIONAL_HEADER.ImageBase
+
+    # cache the section data so that we can avoid pefile overhead
+    section_datas: List[Tuple[VA, VA, bytes]] = []
+    for section in pe.sections:
+        if not section.IMAGE_SCN_MEM_READ:
+            continue
+
+        section_datas.append(
+            (image_base + section.VirtualAddress, 
+             image_base + section.VirtualAddress + section.SizeOfRawData,
+             section.get_data())
+        )
+
+    range_votes = collections.Counter()
+    for instance in get_struct_string_instances(pe):
+        section_start, _, section_data = next(filter(lambda s: s[0] <= instance.address < s[1], section_datas))
+
+        instance_offset = instance.address - section_start
+
+        next_null = section_data.find(b"\x00\x00", instance_offset)
+        if next_null == -1:
+            continue
+
+        prev_null = section_data.rfind(b"\x00\x00", 0, instance_offset)
+        if prev_null == -1:
+            continue
+
+        range_votes[(section_start + prev_null, section_start + next_null)] += 1
+
+    for (prev_null, next_null), count in range_votes.most_common():
+        if count == 1:
+            continue
+
+        logger.debug("range vote: 0x%x 0x%x 0x%x", prev_null + section_start, next_null + section_start, count)
+
+    most_common, count = range_votes.most_common(1)[0]
+    return most_common
+
+
+def get_string_blob_strings(pe: pefile.PE) -> Tuple[VA, str]:
+    image_base = pe.OPTIONAL_HEADER.ImageBase
+   
+    string_blob_range = get_string_blob_range(pe)
+    string_blob_start, string_blob_end = string_blob_range
+    string_blob_size = string_blob_end - string_blob_start
+    string_blob_buf = pe.get_data(string_blob_range[0] - image_base, string_blob_size)
+
+    # initialized with pointers to the beginning and end,
+    # so that when we split by pairs, we can get those bookends.
+    string_blob_pointers: List[VA] = [string_blob_range[0], string_blob_range[1]]
+
+    for instance in get_struct_string_instances(pe):
+        if not (string_blob_range[0] <= instance.address < string_blob_range[1]):
+            continue
+
+        string_blob_pointers.append(instance.address)
+
+    for xref in get_lea_xrefs(pe):
+        if not (string_blob_range[0] <= xref < string_blob_range[1]):
+            continue
+
+        string_blob_pointers.append(xref)
+
+    last_size = 0
+    string_blob_pointers = list(sorted(set(string_blob_pointers)))
+    for start, end in zip(string_blob_pointers, string_blob_pointers[1:]):
+        size = end - start
+
+        if not (string_blob_start <= start < string_blob_end):
+            continue
+
+        if not (string_blob_start <= end < string_blob_end):
+            continue
+
+        string_blob_offset = start - string_blob_start
+        sbuf = string_blob_buf[string_blob_offset : string_blob_offset + size]
+
+        try:
+            s = sbuf.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        if not s:
+            continue
+
+        if last_size > len(s):
+            # today, the string blob is stored in order of length,
+            # small to large,
+            # so we can detect when we missed a string,
+            # for example:
+            #
+            #   0x4aab99:  nmidlelocked=
+            #   0x4aaba7:  on zero Value
+            #   0x4aabb5:  out of range  procedure in        <<< missed!
+            #   0x4aabd1:  to finalizer 
+            #   0x4aabdf:  untyped args 
+            #   0x4aabed: -thread limit
+            #
+            # we probably missed the string: " procedure in "
+            logger.warn("probably missed a string blob string ending at: 0x%x", start - 1)
+
+        yield start, s
+
+
+def xrefs_in_rdata_data_segment(section_data, rdata_start_va, rdata_end_va, arch) -> List[int]:
+    """
+    Find cross-references to a string in the .rdata segment.
+    All cross-references are of the form:
+    00000000004C9D00  19 8C 4A 00 00 00 00 00  0A 00 00 00 00 00 00 00  ..J.............
+    """
+
+    if arch == "amd64":
+        size = 0x10
+        fmt = "<QQ"
+    else:
+        size = 0x8
+        fmt = "<II"
+
+    xrefs_in_rdata_data_segment = list()
+
+    for addr in range(0, len(section_data) - size // 2, size // 2):
+        curr = section_data[addr : addr + size]
+        s_off, s_size = struct.unpack_from(fmt, curr)
+
+        if not (1 <= s_size < 128):
+            continue
+
+        if rdata_start_va <= s_off <= rdata_end_va:
+            xrefs_in_rdata_data_segment.append(s_off)
+
+    return xrefs_in_rdata_data_segment
+
+
 def xrefs_in_text_segment(
     pe: pefile.PE, text_segment_data, text_segment_va, rdata_start_va, rdata_end_va, arch
 ) -> List[int]:
@@ -72,6 +393,7 @@ def xrefs_in_text_segment(
             address = text_segment_va + match.start() + offset + 7 + pe.OPTIONAL_HEADER.ImageBase
             if rdata_start_va <= address <= rdata_end_va:
                 text_segment_xrefs.append(address)
+
     else:
         text_regex = re.compile(b"\x8D(?=.(?P<offset>....))", re.DOTALL)
         for match in text_regex.finditer(text_segment_data):
@@ -308,7 +630,7 @@ def extract_go_strings(sample: Path, min_length=MIN_STR_LEN) -> List[StaticStrin
     return utf_8_parts + stack_strings + static_strings
 
 
-def main(argv=None):
+def amain(argv=None):
     parser = argparse.ArgumentParser(description="Get Go strings")
     parser.add_argument("path", help="file or path to analyze")
     parser.add_argument(
@@ -327,6 +649,29 @@ def main(argv=None):
         addr = strings_obj.offset
         string = strings_obj.string
         print(string, hex(addr))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Get Go strings")
+    parser.add_argument("path", help="file or path to analyze")
+    parser.add_argument(
+        "-n",
+        "--minimum-length",
+        dest="min_length",
+        type=int,
+        default=MIN_STR_LEN,
+        help="minimum string length",
+    )
+    args = parser.parse_args(args=argv)
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    p = pathlib.Path(args.path)
+    buf = p.read_bytes()
+    pe = pefile.PE(data=buf, fast_load=True)
+
+    for va, s in get_string_blob_strings(pe):
+        print(f"{va:#x}: {s}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
here's a work in progress implementation that finds the string blob by counting votes to the ranges between `| 00 00 <string> 00 00 |`.

there's a handful of references that it misses, so im going to continue to try to fix those. i wont have a chance to do that until tomorrow. so i'll mark this PR as in draft status until im happy with the coverage.

@mr-tz for your awareness.